### PR TITLE
add encryption functionality

### DIFF
--- a/lib/ll-innobackup.rb
+++ b/lib/ll-innobackup.rb
@@ -181,7 +181,7 @@ class InnoBackup
     [
      "--parallel=#{backup_parallel}",
      "--compress-threads=#{backup_compress_threads}",
-     ("-encrypt=AES256 --encrypt-key=#{encryption_key}" if is_encrypted?),
+     ("--encrypt=AES256 --encrypt-key=#{encryption_key}" if is_encrypted?),
      '--stream=xbstream --compress'
     ].join(" ")
   end

--- a/lib/ll-innobackup.rb
+++ b/lib/ll-innobackup.rb
@@ -105,6 +105,10 @@ class InnoBackup
     false
   end
 
+  def is_encrypted?
+    !options['encryption_key'].empty?
+  end
+
   def can_full_backup?
     !fully_backed_up_today? && lock?('full')
   end
@@ -143,6 +147,10 @@ class InnoBackup
     @sql_backup_password ||= options['sql_backup_password']
   end
 
+  def encryption_key
+    @encryption_key ||= options['encryption_key']
+  end
+
   def aws_bin
     @aws_bin = options['aws_bin'] ||= '/usr/local/bin/aws'
   end
@@ -170,9 +178,12 @@ class InnoBackup
   end
 
   def innobackup_options
-    "--parallel=#{backup_parallel} "\
-    "--compress-threads=#{backup_compress_threads} "\
-    '--stream=xbstream --compress'
+    [
+     "--parallel=#{backup_parallel}",
+     "--compress-threads=#{backup_compress_threads}",
+     ("-encrypt=AES256 --encrypt-key=#{encryption_key}" if is_encrypted?),
+     '--stream=xbstream --compress'
+    ].join(" ")
   end
 
   def innobackup_command

--- a/ll-innobackup.gemspec
+++ b/ll-innobackup.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'll-innobackup'
-  s.version     = '0.1.18'
+  s.version     = '0.1.19'
   s.summary     = "Livelink Innobackup Script"
   s.description = "A program to conduct innobackup"
   s.authors     = ["Stuart Harland, LiveLink Technology Ltd"]


### PR DESCRIPTION
This should enable the gem to perform encrypted backups if the encryption_key is specified in the innobackupex.json file. If the value is empty a standard (non-encrypted) backup should be performed.

- Checks if the [encryption_key](https://github.com/essjayhch/innobackup-gem/blob/873d387d3aa04d11eaa75246c8471955d23a6523/lib/ll-innobackup.rb#L108) value is set in "/etc/mysql/innobackupex.json"

Had to use i[s_empty?](https://github.com/essjayhch/innobackup-gem/blob/873d387d3aa04d11eaa75246c8471955d23a6523/lib/ll-innobackup.rb#L109) , because is_nil? returns true when the string is empty

- Had to convert [this](https://github.com/essjayhch/innobackup-gem/blob/873d387d3aa04d11eaa75246c8471955d23a6523/lib/ll-innobackup.rb#L180) method into array in order to make append strings to the command based on conditions