### PR TITLE
Added aws-sdk-s3

### DIFF
--- a/lib/ll-innobackup.rb
+++ b/lib/ll-innobackup.rb
@@ -230,12 +230,6 @@ class InnoBackup
     return false
   end
 
-  def aws_command
-    "#{aws_bin} s3 cp #{working_file} s3://#{aws_bucket}/#{aws_backup_file} "\
-    "#{expected_size} #{expires} "\
-    "2> #{aws_log} >> #{aws_log}"
-  end
-
   def valid_commands?
     File.exist?(backup_bin) && File.exist?(aws_bin)
   end

--- a/ll-innobackup.gemspec
+++ b/ll-innobackup.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'll-innobackup'
-  s.version     = '0.1.21'
+  s.version     = '0.1.22'
   s.summary     = "Livelink Innobackup Script"
   s.description = "A program to conduct innobackup"
   s.authors     = ["Stuart Harland, LiveLink Technology Ltd"]
@@ -11,4 +11,5 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.executables << 'll-innobackup'
   s.add_dependency 'activesupport', '= 4.2.6'
+  s.add_dependency 'aws-sdk-s3', '~> 1'
 end


### PR DESCRIPTION
This uses the aws-sdk to upload objects instead of the command line tool.  The sdk's `upload_file` helper method deals with splitting large files into multipart uploads.  By default this uploads the parts in 10 threads.  Although I set the `thread_count` option for some reason this doesn't seem to actually do _anything_ and I have given up trying to get this to work :/



Here are the API docs for `upload_file` https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Object.html#upload_file-instance_method

### How I tested:
I have tested this with a 2GB dummy file and it seems to work as expected.

This dockerfile replicates the environment that this gem will be used in:
```
FROM ruby:1.9.3-wheezy

RUN gem install minitest --version 5.5.1 && \
gem install activesupport --version 4.2.6 && \
gem install aws-sdk-s3

```

Prerequisites:
Create dummy state lock files and state files, install the new innobackup gem, and source aws_creds
```
cd ~/git/innobackup-gem
gem build ll-innobackup.gemspec
docker build -t innobackgem_dev:1 .
docker run -v $HOME:$HOME -it innobackupgem:_dev:1 bash
echo <SOME STATE JSON> > /tmp/backup_full_state && touch /tmp/backup_full.lock
gem install -l /home/adam/innobackup-gem/ll-innobackup-0.1.22.gem
source /home/adam/.aws_creds

```

### Try to upload a valid file:
```
#In the container
irb
irb(main):004:0> require 'll-innobackup'
irb(main):004:0> thing = LL::InnoBackup.new(LL::InnoBackup.options)
irb(main):004:0> thing.s3object_uploaded?('adam-test-sql-backup', 'thing.txt', '/home/adam/thing.txt')
true
```
### Try to upload a non existent file:
```
irb(main):004:0> thing.s3object_uploaded?('adam-test-sql-backup', 'thing', '/home/adam/NOT_A_FILE.txt')
Error uploading object: No such file or directory - /home/adam/NOT_A_FILE.txt
=> false
```
