### PR TITLE
Remove hardcoded region oops!

### DIFF
--- a/lib/ll-innobackup.rb
+++ b/lib/ll-innobackup.rb
@@ -73,7 +73,7 @@ class InnoBackup
     @lock_files = {}
     @state_files = {}
     @type = backup_type
-    @s3 = Aws::S3::Resource.new(region: 'eu-west-1')
+    @s3 = Aws::S3::Resource.new()
   end
 
   def aws_log

--- a/ll-innobackup.gemspec
+++ b/ll-innobackup.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'll-innobackup'
-  s.version     = '0.1.22'
+  s.version     = '0.1.23'
   s.summary     = "Livelink Innobackup Script"
   s.description = "A program to conduct innobackup"
   s.authors     = ["Stuart Harland, LiveLink Technology Ltd"]


### PR DESCRIPTION
The SDK will read from read `AWS_REGION` environment variable by default. 

Testing in my dev container.

```
export AWS_REGION='eu-west-1'
irb
irb(main):001:0> require 'll-innobackup'
irb(main):002:0> thing = LL::InnoBackup.new(LL::InnoBackup.options)
irb(main):060:0> thing.s3.client.config.region
=> "eu-west-1"

--------------------
export AWS_REGION='us-east-2'
irb
irb(main):001:0> require 'll-innobackup'
irb(main):002:0> thing = LL::InnoBackup.new(LL::InnoBackup.options)
irb(main):003:0> thing.s3.client.config.region
=> "us-east-2"

```