### PR TITLE
Specify downgraded minitest version for Ruby < 2.2

### DIFF
--- a/ll-innobackup.gemspec
+++ b/ll-innobackup.gemspec
@@ -10,6 +10,10 @@ Gem::Specification.new do |s|
     'http://rubygems.org/gems/ll-innobackup'
   s.license       = 'MIT'
   s.executables << 'll-innobackup'
+
   s.add_dependency 'activesupport', '= 4.2.6'
-  s.add_dependency 'aws-sdk-s3', '~> 1'
+  s.add_dependency 'aws-sdk-s3',    '~> 1'
+
+  # minitest 5.12.1 requires ruby 2.2+
+  s.add_dependency 'minitest', '< 5.12.1' if RUBY_VERSION < '2.2'
 end

--- a/ll-innobackup.gemspec
+++ b/ll-innobackup.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'll-innobackup'
-  s.version     = '0.1.23'
+  s.version     = '0.1.24'
   s.summary     = "Livelink Innobackup Script"
   s.description = "A program to conduct innobackup"
   s.authors     = ["Stuart Harland, LiveLink Technology Ltd"]


### PR DESCRIPTION
`minitest 5.12.1` added ruby > 2.2 requirement to gem specification. This change allows to install gem at hosts with Ruby 1.9.3 too.

