### PR TITLE
Do not use RUBY_VERSION in gemspec

### DIFF
--- a/ll-innobackup.gemspec
+++ b/ll-innobackup.gemspec
@@ -13,7 +13,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '= 4.2.6'
   s.add_dependency 'aws-sdk-s3',    '~> 1'
-
-  # minitest 5.12.1 requires ruby 2.2+
-  s.add_dependency 'minitest', '< 5.12.1' if RUBY_VERSION < '2.2'
+  s.add_dependency 'minitest',      '5.12.0'
 end

--- a/ll-innobackup.gemspec
+++ b/ll-innobackup.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'll-innobackup'
-  s.version     = '0.1.24'
+  s.version     = '0.1.25'
   s.summary     = "Livelink Innobackup Script"
   s.description = "A program to conduct innobackup"
   s.authors     = ["Stuart Harland, LiveLink Technology Ltd"]


### PR DESCRIPTION
Global RUBY_VERSION will not work for runtime dependencies since the logic will be evaluated at gem-build time and not when the gem runs in another environment. Let's declare required `minitest` version unconditionally until we upgrade Ruby 2 as we don't care about minitest transitive dependency in this gem – we don't refer to `ActiveSupport::TestCase`.